### PR TITLE
DNEXT-14698: Correcting compilation failure on Linux for open source for Domino CAPI samples

### DIFF
--- a/makeEnvLinux.mak
+++ b/makeEnvLinux.mak
@@ -4,7 +4,7 @@
 #
 
 #CC defines the compiler.
-CC = g++
+CC = g++ -std=c++98 -pedantic
 
 # Set CCOPTS - the compiler options.
 CCOPTS = -c -m64
@@ -19,5 +19,5 @@ DEFINES = -DGCC3 -DGCC4 -fno-strict-aliasing -DGCC_LBLB_NOT_SUPPORTED -Wformat -
 INCDIR = -I$(NOTES_CAPI)/include -I$(NOTES_CAPI)/samples
 
 # set LIBS to list all the libraries ld should link with.
-LIBS = -lnotes -lm -lnsl -lpthread -lc -lresolv -ldl
+LIBS = -lnotes -lm -lpthread -lc -lresolv -ldl
 

--- a/samples/advsrvr/cluster/clumoncm.c
+++ b/samples/advsrvr/cluster/clumoncm.c
@@ -1306,7 +1306,7 @@ void setThresholdInfo (char *szServerName, int iThreshold)
     nError = RemoteCommand (szServerName, szCommand, 
                             szServerResponse, &wResponseLen);
     
-    * Return if error with remote command */
+    /* Return if error with remote command */
     if (nError != NOERROR)
         goto Cleanup;
 


### PR DESCRIPTION
Following files created compilation error while compiling the Domino CAPI samples which is open sourced
https://github.com/HCL-TECH-SOFTWARE/domino-c-api-samples/

1. makeEnvLinux.mak
2. clumoncm.c
3. response.c