### PR TITLE
fixed compiler syntax error in u_secdom.c by removing 'SOLARIS ||'

### DIFF
--- a/samples/admin/secdom/u_secdom.c
+++ b/samples/admin/secdom/u_secdom.c
@@ -35,7 +35,7 @@ extern "C" {
 #include <string.h>
 
 /* unix authentication includes */
-#ifdef SOLARIS || LINUX
+#ifdef LINUX
 #include <shadow.h>
 #include <crypt.h>
 #endif
@@ -57,7 +57,7 @@ int unknown = 1;
 /* Get the unix record for this user */
 
 
-#ifdef SOLARIS || LINUX
+#ifdef LINUX
     struct spwd result;
 #endif
 
@@ -68,7 +68,7 @@ int unknown = 1;
 
 /* Get the unix record for this user */
 
-#ifdef SOLARIS || LINUX
+#ifdef LINUX
 
 if (getspnam_r(userName, &result, buffer, sizeof(buffer))) 
 {


### PR DESCRIPTION
Multiple warnings similar to
```
 samples/admin/secdom/u_secdom.c:38:16: warning: extra tokens at end of #ifdef directive
   38 | #ifdef SOLARIS || LINUX
```
masked additional compiler errors. 

`#ifdef` is a special abbreviation for `#if defined(...)`. However, it can only be used for a single macro and does not allow for logical operations.  So, if checking for multiple macros, use `#if` with the `defined()` operator instead. 

But as Solaris is no longer supported by HCL, I fixed the syntactically incorrect "SOLARIS ||" by removing it completely from  `samples/admin/secdom/u_secdom.c`.