### PR TITLE
Isseu 65: added compatibility with glibc getspnam_r()

### DIFF
--- a/samples/admin/secdom/u_secdom.c
+++ b/samples/admin/secdom/u_secdom.c
@@ -35,7 +35,7 @@ extern "C" {
 #include <string.h>
 
 /* unix authentication includes */
-#ifdef SOLARIS || LINUX
+#ifdef LINUX
 #include <shadow.h>
 #include <crypt.h>
 #endif
@@ -57,7 +57,7 @@ int unknown = 1;
 /* Get the unix record for this user */
 
 
-#ifdef SOLARIS || LINUX
+#ifdef LINUX
     struct spwd result;
 #endif
 
@@ -68,7 +68,7 @@ int unknown = 1;
 
 /* Get the unix record for this user */
 
-#ifdef SOLARIS || LINUX
+#ifdef LINUX
 
 if (getspnam_r(userName, &result, buffer, sizeof(buffer))) 
 {

--- a/samples/admin/secdom/u_secdom.c
+++ b/samples/admin/secdom/u_secdom.c
@@ -58,7 +58,8 @@ int unknown = 1;
 
 
 #ifdef LINUX
-    struct spwd result;
+    struct spwd pwd;
+	struct spwd *ppwd;
 #endif
 
 #ifdef AIX
@@ -70,14 +71,14 @@ int unknown = 1;
 
 #ifdef LINUX
 
-if (getspnam_r(userName, &result, buffer, sizeof(buffer))) 
+if (getspnam_r(userName, &pwd, buffer, sizeof(buffer), &ppwd)) 
 {
 /* Encrypt the password and see if it matches the
  * encrypted password from the user's record.
  */
     char *thisCrypt = NULL;
-    thisCrypt = (char *)crypt(password, result.sp_pwdp);
-    if (strcmp (result.sp_pwdp, thisCrypt) == 0) {
+    thisCrypt = (char *)crypt(password, pwd.sp_pwdp);
+    if (strcmp (pwd.sp_pwdp, thisCrypt) == 0) {
         return success;
     } else {
         return error;


### PR DESCRIPTION
fixed compiler error "error: too few arguments to function 'int getspnam_r'" by adding necessary parameters.