### PR TITLE
DNEXT-33978: CAPI testing in WINDOWS 64

### DIFF
--- a/samples/misc/ftindexreq/ftindexreq.c
+++ b/samples/misc/ftindexreq/ftindexreq.c
@@ -36,7 +36,7 @@
 
 /* OS and C include files */
 
-#if !defined(UNIX)
+#if defined(W64)
 #include <windows.h>
 #endif
 

--- a/samples/misc/ftindexreq/ftindexreq.c
+++ b/samples/misc/ftindexreq/ftindexreq.c
@@ -36,7 +36,10 @@
 
 /* OS and C include files */
 
+#if !defined(UNIX)
 #include <windows.h>
+#endif
+//#include <windows.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -49,6 +52,12 @@
 #include <osmem.h>
 #include <osmisc.h>
 #include <ostime.h>
+#include <client.h>
+
+#if defined(UNIX)
+#include <unistd.h>
+#endif
+
 
 #if defined(CAPI_TESTING) 
 #include "printlog.h" 
@@ -169,7 +178,11 @@ short IsRemoteDbIndexed(DBHANDLE hDB, DWORD waitTime)
       }
 
       PRINTLOG("\nWaiting for database to be full text indexed...");
-      Sleep(1000L);
+#if defined(UNIX)
+		usleep(1000L);
+#else
+		Sleep(1000L);
+#endif
       wCounter++;
     } while (ERR(sErr) != NOERROR);
 

--- a/samples/misc/ftindexreq/ftindexreq.c
+++ b/samples/misc/ftindexreq/ftindexreq.c
@@ -39,7 +39,7 @@
 #if !defined(UNIX)
 #include <windows.h>
 #endif
-//#include <windows.h>
+
 #include <stdio.h>
 #include <string.h>
 

--- a/samples/misc/nsf_dump/dumpcd.c
+++ b/samples/misc/nsf_dump/dumpcd.c
@@ -3949,6 +3949,7 @@ void  LNPUBLIC   DumpCDButton( char *RecordPtr, DWORD RecordLength )
 	if (wFlags & BUTTON_RUNFLAG_MINIMUM)	  fprintf( dumpfile, "MINIMUM " );
 	if (wFlags & BUTTON_RUNFLAG_CONTENT)	  fprintf( dumpfile, "CONTENT " );
 	if (wFlags & BUTTON_RUNFLAG_PROPORTIONAL) fprintf( dumpfile, "PROPORTIONAL " );       /* New for Notes/Domino 6 */
+	//if (wFlags & BUTTON_FOCUS_ON)			  fprintf( dumpfile, "FOCUS_ON " );			  /* Macro got removed from Notes/Domino in V14.5.1 */
 	if (wFlags & BUTTON_RUNFLAG_WIDTH_MASK)   fprintf( dumpfile, "WIDTH_MASK " );
 	if (wFlags & BUTTON_EDGE_ROUNDED)		  fprintf( dumpfile, "EDGE_ROUNDED " );       /* New for Notes/Domino 6 */
 	if (wFlags & BUTTON_EDGE_SQUARE)		  fprintf( dumpfile, "BUTTON_EDGE_SQUARE " ); /* New for Notes/Domino 6 */

--- a/samples/misc/nsf_dump/dumpcd.c
+++ b/samples/misc/nsf_dump/dumpcd.c
@@ -3949,7 +3949,6 @@ void  LNPUBLIC   DumpCDButton( char *RecordPtr, DWORD RecordLength )
 	if (wFlags & BUTTON_RUNFLAG_MINIMUM)	  fprintf( dumpfile, "MINIMUM " );
 	if (wFlags & BUTTON_RUNFLAG_CONTENT)	  fprintf( dumpfile, "CONTENT " );
 	if (wFlags & BUTTON_RUNFLAG_PROPORTIONAL) fprintf( dumpfile, "PROPORTIONAL " );       /* New for Notes/Domino 6 */
-	if (wFlags & BUTTON_FOCUS_ON)			  fprintf( dumpfile, "FOCUS_ON " );			  /* New for Notes/Domino 6 */
 	if (wFlags & BUTTON_RUNFLAG_WIDTH_MASK)   fprintf( dumpfile, "WIDTH_MASK " );
 	if (wFlags & BUTTON_EDGE_ROUNDED)		  fprintf( dumpfile, "EDGE_ROUNDED " );       /* New for Notes/Domino 6 */
 	if (wFlags & BUTTON_EDGE_SQUARE)		  fprintf( dumpfile, "BUTTON_EDGE_SQUARE " ); /* New for Notes/Domino 6 */


### PR DESCRIPTION
In V14.5.1 below macro got removed from notes repo. So, removed macro from C API Toolkit as well.
#define BUTTON_FOCUS_ON                0x8000    /* button has focus    */ 
PR: https://git.cwp.pnp-hcl.com/notes-domino/notes/pull/25574/files#diff-993e463cc570f554efdb7c5da4ef58d3a450a30f2b5d55330d494bbd2064b094

Effected samples in C API Toolkit
1. misc/dump_nsf 
       
